### PR TITLE
Kh cleanup names

### DIFF
--- a/cert_issuer/__init__.py
+++ b/cert_issuer/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '2.0b8'
+__version__ = '2.0b9'

--- a/cert_issuer/issue_certificates.py
+++ b/cert_issuer/issue_certificates.py
@@ -59,7 +59,7 @@ def main(app_config, secure_signer=None, prepared_inputs=None):
                     transaction_handler=transaction_handler,
                     max_retry=app_config.max_retry,
                     prepared_inputs=prepared_inputs)
-    transaction_cost = issuer.calculate_cost_for_certificate_batch()
+    transaction_cost = issuer.estimate_cost_for_certificate_batch()
     logging.info('Total cost will be %d satoshis', transaction_cost)
 
     # ensure the issuing address has sufficient balance

--- a/cert_issuer/issuer.py
+++ b/cert_issuer/issuer.py
@@ -25,8 +25,8 @@ class Issuer:
         self.tree = MerkleTools(hash_type='sha256')
         self.prepared_inputs = prepared_inputs
 
-    def calculate_cost_for_certificate_batch(self):
-        return self.transaction_handler.calculate_cost_for_certificate_batch()
+    def estimate_cost_for_certificate_batch(self):
+        return self.transaction_handler.estimate_cost_for_certificate_batch()
 
     def sign_batch(self):
         with FinalizableSigner(self.secure_signer) as signer:
@@ -59,7 +59,7 @@ class Issuer:
                         logging.error(error_message)
                         raise InsufficientFundsError(error_message)
 
-                    cost = self.transaction_handler.calculate_cost_for_certificate_batch()
+                    cost = self.transaction_handler.estimate_cost_for_certificate_batch()
                     current_total = 0
                     inputs = []
                     random.shuffle(spendables)

--- a/cert_issuer/issuer.py
+++ b/cert_issuer/issuer.py
@@ -26,7 +26,10 @@ class Issuer:
         self.prepared_inputs = prepared_inputs
 
     def estimate_cost_for_certificate_batch(self):
-        return self.transaction_handler.estimate_cost_for_certificate_batch()
+        if self.prepared_inputs:
+            return self.transaction_handler.estimate_cost_for_certificate_batch(num_inputs=len(self.prepared_inputs))
+        else:
+            return self.transaction_handler.estimate_cost_for_certificate_batch()
 
     def sign_batch(self):
         with FinalizableSigner(self.secure_signer) as signer:

--- a/cert_issuer/tx_utils.py
+++ b/cert_issuer/tx_utils.py
@@ -39,11 +39,11 @@ class TransactionCostConstants(object):
         return self.recommended_tx_fee * COIN
 
 
-def create_trx(op_return_val, issuing_transaction_cost, issuing_address, tx_outs, tx_inputs):
+def create_trx(op_return_val, issuing_transaction_fee, issuing_address, tx_outs, tx_inputs):
     """
 
     :param op_return_val:
-    :param issuing_transaction_cost:
+    :param issuing_transaction_fee:
     :param issuing_address:
     :param tx_outs:
     :param tx_input:
@@ -57,7 +57,7 @@ def create_trx(op_return_val, issuing_transaction_cost, issuing_address, tx_outs
         value_in += tx_input.coin_value
 
     # send change back to our address
-    amount = value_in - issuing_transaction_cost
+    amount = value_in - issuing_transaction_fee
     if amount > 0:
         change_out = create_transaction_output(issuing_address, amount)
         tx_outs = tx_outs + [change_out]


### PR DESCRIPTION
Transaction fees calculated up front are estimates until we know exact number of inputs, and whether change is required. Fix naming and and also use precise counts as soon as we know them.