### PR TITLE
add: missing argument for get_providers_for_chain

### DIFF
--- a/cert_issuer/ethereum/connectors.py
+++ b/cert_issuer/ethereum/connectors.py
@@ -129,5 +129,5 @@ rop_provider_list.append(EtherscanBroadcaster('https://ropsten.etherscan.io/api'
 connectors[Chain.ethereum_ropsten] = rop_provider_list
 
 
-def get_providers_for_chain(chain):
+def get_providers_for_chain(chain, local_node=False):
     return connectors[chain]


### PR DESCRIPTION
When calling get_providers_for_chain, it should have an argument "local_node" tho it is not used.