### PR TITLE
Removed ethereum testnet, should use ropsten instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Edit your conf.ini file (the config file for this application).
 ```
 issuing_address = <issuing-address>
 
-chain=<bitcoin_regtest|bitcoin_testnet|bitcoin_mainnet|ethereum_testnet|ethereum_ropsten|ethereum_mainnet|mockchain>
+chain=<bitcoin_regtest|bitcoin_testnet|bitcoin_mainnet|ethereum_ropsten|ethereum_mainnet|mockchain>
     
 usb_name = </Volumes/path-to-usb/>
 key_file = <file-you-saved-pk-to>

--- a/cert_issuer/config.py
+++ b/cert_issuer/config.py
@@ -46,7 +46,7 @@ def add_arguments(p):
                    help='Default path to work directory, storing intermediate outputs. This gets deleted in between runs.')
     p.add_argument('--max_retry', default=10, type=int, help='Maximum attempts to retry transaction on failure')
     p.add_argument('--chain', default='bitcoin_regtest',
-                   help='Which chain to use. Default is bitcoin_regtest (which is how the docker container is configured). Other options are bitcoin_testnet bitcoin_mainnet, mockchain, ethereum_mainnet, ethereum_ropsten, ethereum_testnet')
+                   help='Which chain to use. Default is bitcoin_regtest (which is how the docker container is configured). Other options are bitcoin_testnet bitcoin_mainnet, mockchain, ethereum_mainnet, ethereum_ropsten')
 
     p.add_argument('--safe_mode', dest='safe_mode', default=True, action='store_true',
                    help='Used to make sure your private key is not plugged in with the wifi.')

--- a/cert_issuer/ethereum/__init__.py
+++ b/cert_issuer/ethereum/__init__.py
@@ -59,7 +59,7 @@ def instantiate_blockchain_handlers(app_config):
     if chain == Chain.mockchain:
         transaction_handler = MockTransactionHandler()
     # ethereum chains
-    elif chain == Chain.ethereum_mainnet or chain == Chain.ethereum_ropsten or chain == Chain.ethereum_testnet:
+    elif chain == Chain.ethereum_mainnet or chain == Chain.ethereum_ropsten:
         cost_constants = EthereumTransactionCostConstants(app_config.gas_price, app_config.gas_limit)
         connector = EthereumServiceProviderConnector(chain, app_config.api_token)
         transaction_handler = EthereumTransactionHandler(connector, cost_constants, secret_manager,

--- a/cert_issuer/issue_certificates.py
+++ b/cert_issuer/issue_certificates.py
@@ -28,7 +28,7 @@ def issue(app_config, certificate_batch_handler, transaction_handler):
 
 def main(app_config):
     chain = app_config.chain
-    if chain == Chain.ethereum_mainnet or chain == Chain.ethereum_ropsten or chain == Chain.ethereum_testnet:
+    if chain == Chain.ethereum_mainnet or chain == Chain.ethereum_ropsten:
         from cert_issuer import ethereum
         certificate_batch_handler, transaction_handler, connector = ethereum.instantiate_blockchain_handlers(app_config)
     else:

--- a/conf_ethtest.ini
+++ b/conf_ethtest.ini
@@ -1,6 +1,6 @@
 issuing_address = <Your Ethereum address> 
 
-blockchain = <ethereum_testnet|ethereum_ropsten|ethereum_mainnet>
+chain = <ethereum_ropsten|ethereum_mainnet>
 
 usb_name=</Volumes/path-to-usb/>
 key_file=<file-you-saved-pk-to>

--- a/conf_template.ini
+++ b/conf_template.ini
@@ -13,7 +13,7 @@ usb_name = </Volumes/path-to-usb/>
 key_file = <file-you-saved-pk-to>
 
 # which blockchain; bitcoin_regtest is default
-chain=<bitcoin_regtest|bitcoin_testnet|bitcoin_mainnet|ethereum_testnet|ethereum_ropsten|ethereum_mainnet|mockchain>
+chain=<bitcoin_regtest|bitcoin_testnet|bitcoin_mainnet|ethereum_ropsten|ethereum_mainnet|mockchain>
 
 # this disables the wifi check, and should only be used recommended during testing
 no_safe_mode


### PR DESCRIPTION
Removing testnet from the Ethereum options, as part of Issue https://github.com/blockchain-certificates/cert-issuer/issues/72

`ethereum_ropsten` should be used instead. 