### PR TITLE
Removing 2nd instance of logger

### DIFF
--- a/cert_issuer/config.py
+++ b/cert_issuer/config.py
@@ -102,6 +102,4 @@ def get_config():
             bitcoin_chain_for_python_bitcoinlib = Chain.bitcoin_regtest
         bitcoin.SelectParams(chain_to_bitcoin_network(bitcoin_chain_for_python_bitcoinlib))
 
-    configure_logger()
-
     return parsed_config


### PR DESCRIPTION
Logging is happening twice, due to `configure_logger()` at the beginning of the method and this one at the end.