### PR TITLE
Feature/add docker web config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,36 @@
-FROM ubuntu:18.04
-maintainer kim duffy "kimhd@mit.edu"
-maintainer yancy ribbens "yribbens@credly.com"
+FROM seegno/bitcoind:0.13-alpine
+MAINTAINER Kim Duffy "kimhd@mit.edu"
 
-RUN apt-get update -qq && apt-get install -y git wget build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3 libboost-all-dev libminiupnpc-dev libzmq3-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler libqrencode-dev
+COPY . /cert-issuer
+COPY conf_regtest.ini /etc/cert-issuer/conf.ini
 
-# Checkout bitcoin source
-RUN mkdir /bitcoin-source
-WORKDIR /bitcoin-source
-RUN git clone https://github.com/bitcoin/bitcoin.git
+RUN apk add --update \
+        bash \
+        ca-certificates \
+        curl \
+        gcc \
+        gmp-dev \
+        libffi-dev \
+        libressl-dev \
+        linux-headers \
+        make \
+        musl-dev \
+        python \
+        python3 \
+        python3-dev \
+        tar \
+    && python3 -m ensurepip \
+    && pip3 install --upgrade pip setuptools \
+    && mkdir -p /etc/cert-issuer/data/unsigned_certificates \
+    && mkdir /etc/cert-issuer/data/blockchain_certificates \
+    && mkdir ~/.bitcoin \
+    && echo $'rpcuser=foo\nrpcpassword=bar\nrpcport=8332\nregtest=1\nrelaypriority=0\nrpcallowip=127.0.0.1\nrpcconnect=127.0.0.1\n' > /root/.bitcoin/bitcoin.conf \
+    && pip3 install /cert-issuer/. \
+    && rm -r /usr/lib/python*/ensurepip \
+    && rm -rf /var/cache/apk/* \
+    && rm -rf /root/.cache \
+    && sed -i.bak s/==1\.0b1/\>=1\.0\.2/g /usr/lib/python3.*/site-packages/merkletools-1.0.2-py3.*.egg-info/requires.txt
 
-# Install Berkley Database
-RUN wget http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz
-RUN tar -xvf db-4.8.30.NC.tar.gz
-WORKDIR /bitcoin-source/db-4.8.30.NC/build_unix
-RUN mkdir -p build
-RUN BDB_PREFIX=$(pwd)/build
-RUN ../dist/configure --disable-shared --enable-cxx --with-pic --prefix=$BDB_PREFIX
-RUN make install
 
-# install bitcoin 0.16.3
-WORKDIR /bitcoin-source/bitcoin
-RUN ./autogen.sh
-RUN ./configure CPPFLAGS="-I${BDB_PREFIX}/include/ -O2" LDFLAGS="-L${BDB_PREFIX}/lib/" --with-gui
-RUN make
-RUN make install
+ENTRYPOINT bitcoind -daemon && bash
+

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,66 @@
+FROM ubuntu:18.04
+maintainer yancy ribbens "yribbens@credly.com"
+
+RUN apt-get update -qq && apt-get install -y git wget build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3 libboost-all-dev libminiupnpc-dev libzmq3-dev python3-pip locales vim python3.6 python3.6-dev uwsgi uwsgi-src uuid-dev libcap-dev libpcre3-dev python-pip python-dev nginx
+
+# Checkout bitcoin source
+RUN mkdir /bitcoin-source
+WORKDIR /bitcoin-source
+RUN git clone https://github.com/bitcoin/bitcoin.git
+
+# Install Berkley Database
+RUN wget http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz
+RUN tar -xvf db-4.8.30.NC.tar.gz
+WORKDIR /bitcoin-source/db-4.8.30.NC/build_unix
+RUN mkdir -p build
+RUN BDB_PREFIX=$(pwd)/build
+RUN ../dist/configure --disable-shared --enable-cxx --with-pic --prefix=$BDB_PREFIX
+RUN make install
+
+# install bitcoin 0.16.3
+WORKDIR /bitcoin-source/bitcoin
+RUN git checkout tags/v0.16.3
+RUN ./autogen.sh
+RUN ./configure CPPFLAGS="-I${BDB_PREFIX}/include/ -O2" LDFLAGS="-L${BDB_PREFIX}/lib/" --without-gui
+RUN make
+RUN make install
+
+# configure bitcoin network
+ARG NETWORK=testnet
+ARG RPC_USER=foo
+ARG RPC_PASSWORD=bar
+RUN mkdir -p ~/.bitcoin
+RUN echo "rpcuser=${RPC_USER}\nrpcpassword=${RPC_PASSWORD}\n${NETWORK}=1\nrpcport=8332\nrpcallowip=127.0.0.1\nrpcconnect=127.0.0.1\n" > /root/.bitcoin/bitcoin.conf
+
+# default to UTF8 character set
+ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LC_TYPE en_US.UTF-8
+RUN locale-gen en_US.UTF-8
+
+# configure cert-issuer
+ARG ISSUER=<issuing-address>
+COPY . /cert-issuer
+COPY conf_regtest.ini /etc/cert-issuer/conf.ini
+RUN mkdir -p /etc/cert-issuer/
+WORKDIR /cert-issuer
+RUN pip3 install cert-issuer
+RUN pip3 install -r requirements.txt
+RUN sed -i.bak "s/<issuing-address>/$ISSUER/g" /etc/cert-issuer/conf.ini
+
+# configure wsgi
+ENV PYTHON python3.6
+WORKDIR /root
+RUN uwsgi --build-plugin "/usr/src/uwsgi/plugins/python python36"
+RUN cp /root/python36_plugin.so /cert-issuer
+RUN chmod 644 /cert-issuer/python36_plugin.so
+RUN virtualenv -p python3 venv
+RUN pip3 install uwsgi flask
+
+# configure nginx
+EXPOSE 80
+WORKDIR /cert-issuer
+COPY cert_issuer_site /etc/nginx/sites-available
+RUN ln -s /etc/nginx/sites-available/cert_issuer_site /etc/nginx/sites-enabled
+ENTRYPOINT service nginx start && uwsgi --ini wsgi.ini && bitcoind -daemon && bash

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -66,4 +66,4 @@ COPY cert_issuer_site /etc/nginx/sites-available
 RUN ln -s /etc/nginx/sites-available/cert_issuer_site /etc/nginx/sites-enabled
 RUN sed -i.bak "s/<server-name>/$SERVER/g" /etc/nginx/sites-available/cert_issuer_site
 RUN sed -i.bak "s/# server_names_hash_bucket_size 64/server_names_hash_bucket_size 128/g" /etc/nginx/nginx.conf
-ENTRYPOINT bitcoind -daemon && service nginx start && uwsgi --ini wsgi.ini && bash
+ENTRYPOINT bitcoind -daemon && service nginx start && uwsgi --ini wsgi.ini

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -26,7 +26,7 @@ RUN make
 RUN make install
 
 # configure bitcoin network
-ARG NETWORK=testnet
+ARG NETWORK=regtest
 ARG RPC_USER=foo
 ARG RPC_PASSWORD=bar
 RUN mkdir -p ~/.bitcoin

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -59,8 +59,11 @@ RUN virtualenv -p python3 venv
 RUN pip3 install uwsgi flask
 
 # configure nginx
+ARG SERVER=<server-name>
 EXPOSE 80
 WORKDIR /cert-issuer
 COPY cert_issuer_site /etc/nginx/sites-available
 RUN ln -s /etc/nginx/sites-available/cert_issuer_site /etc/nginx/sites-enabled
-ENTRYPOINT service nginx start && uwsgi --ini wsgi.ini && bitcoind -daemon && bash
+RUN sed -i.bak "s/<server-name>/$SERVER/g" /etc/nginx/sites-available/cert_issuer_site
+RUN sed -i.bak "s/# server_names_hash_bucket_size 64/server_names_hash_bucket_size 128/g" /etc/nginx/nginx.conf
+ENTRYPOINT bitcoind -daemon && service nginx start && uwsgi --ini wsgi.ini && bash

--- a/README.md
+++ b/README.md
@@ -208,15 +208,6 @@ To issue to the ethereum blockchain, run the following:
 python setup.py experimental --blockchain=ethereum
 
 ```
-### Configure nginx
-
-If the Dockerfile.web was used, the following file must be configured to include the server URL:
-
-```
-vim /etc/nginx/sites-available/cert_issuer_site
-```
-
-at a minimum, you'll need to add your servername in place of <server-name>.  This file is also where you may wish to add other authentication options and enable SSL.
 
 ### Create a Bitcoin issuing address
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ experimenting only.
     docker build -t bc/cert-issuer:1.0 .
     ```
 
+    Optionally, the following image can built which is web enabled.  This will expose port 80 inside the container and receive web requests, passing each requests to cert_issuer.
+
+    ```
+    docker build -t bc/cert-issuer:1.0 -f Dockerfile.web .
+    ```
+
 4. Read before running!
 
     - Once you launch the docker container, you will make some changes using your personal issuing information. This flow mirrors what you would if you were issuing real certificates.
@@ -72,6 +78,14 @@ Ensure your docker image is running and bitcoind process is started
     # If you created your own unsigned certificate using cert-tools (assuming you placed it under data/unsigned_certificates):
     cp <cert-issuer-home>/data/unsigned_certificates/<your-cert-guid>.json /etc/cert-issuer/data/unsigned_certificates/
     ```
+
+    Alternatively, if the web image was build, a post request can be issued.  Please read the additonal instructions for configuring the web server.
+
+    ```
+    POST http://<server address>/cert_issuer/api/v1.0/issue
+    ```
+
+    The above post request will return a JSON signature that can be used as proof of issuance.
 
 2. Make sure you have enough BTC in your issuing address.
 
@@ -194,6 +208,15 @@ To issue to the ethereum blockchain, run the following:
 python setup.py experimental --blockchain=ethereum
 
 ```
+### Configure nginx
+
+If the Dockerfile.web was used, the following file must be configured to include the server URL:
+
+```
+vim /etc/nginx/sites-available/cert_issuer_site
+```
+
+at a minimum, you'll need to add your servername in place of <server-name>.  This file is also where you may wish to add other authentication options and enable SSL.
 
 ### Create a Bitcoin issuing address
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ experimenting only.
     ```
     NETWORK=regtest 
     RPC_USER=foo
-    RPC_PASSWORD=ba
+    RPC_PASSWORD=bar
     ISSUER=<issuing-address>
     SERVER=<server-name>
     ```

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ experimenting only.
     docker run -it bc/cert-issuer:1.0 bash
     ```
 
-  If you built the web container, you'll need to expose the required ports at run time:
+    If you built the web container, you'll need to expose the required ports at run time:
+
 
     ```
     sudo docker run -it -p 80:80 bc/cert-issuer:1.0

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ experimenting only.
     RPC_PASSWORD=ba
     ISSUER=<issuing-address>
     SERVER=<server-name>
-
-
+    ```
 
 4. Read before running!
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ experimenting only.
     docker run -it bc/cert-issuer:1.0 bash
     ```
 
+  If you built the web container, you'll need to expose the required ports at run time:
+
+    ```
+    sudo docker run -it -p 80:80 bc/cert-issuer:1.0
+    ```
+
 ## Create issuing address
 
 __Important__: this is a simplification to avoid using a USB, which needs to be inserted and removed during the

--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ experimenting only.
     docker build -t bc/cert-issuer:1.0 -f Dockerfile.web .
     ```
 
+    Additionally, build args can be passed to the container at build time, for example:
+    ```
+    docker build -t bc/cert-issuer:1.0 -f Dockerfile.web --build-arg NETWORK=testnet --build-arg SERVER=ec2-31-415-59-265.us-west-1.compute.amazonaws.com
+    ```
+
+    The list of build-args and the default values are as follows:
+    ```
+    NETWORK=regtest 
+    RPC_USER=foo
+    RPC_PASSWORD=ba
+    ISSUER=<issuing-address>
+    SERVER=<server-name>
+
+
+
 4. Read before running!
 
     - Once you launch the docker container, you will make some changes using your personal issuing information. This flow mirrors what you would if you were issuing real certificates.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ experimenting only.
     docker build -t bc/cert-issuer:1.0 .
     ```
 
-    Optionally, the following image can built which is web enabled.  This will expose port 80 inside the container and receive web requests, passing each requests to cert_issuer.
+    Optionally, the following image can built which is web-enabled.  This will expose port 80 inside the container and receive web requests, passing each requests to cert_issuer.
 
     ```
     docker build -t bc/cert-issuer:1.0 -f Dockerfile.web .

--- a/app.py
+++ b/app.py
@@ -26,4 +26,4 @@ def issue():
     return json.dumps(certificate_batch_handler.proof)
 
 if __name__ == '__main__':
-    app.run()
+    app.run(host='0.0.0.0')

--- a/cert_issuer_site
+++ b/cert_issuer_site
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    server_name <server-name>;
+
+    location / {
+        uwsgi_pass 127.0.0.1:5000;
+        include uwsgi_params;
+    }
+}

--- a/wsgi.ini
+++ b/wsgi.ini
@@ -1,0 +1,11 @@
+[uwsgi]
+module = wsgi:app
+master = true
+processes = 5
+
+socket = 127.0.0.1:5000
+chmod-socket = 660
+vacuum = true
+plugin = python36
+
+die-on-term = true

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,4 @@
+from app import app
+  
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Adds `docker.web` which can be used to build a web-enabled image which serves web requests with nginx.  There are some other improvements in this image including a more current version of bitcoind version `"subversion": "/Satoshi:0.16.3/"` which is compiled from source.  The current `Docker` image contains an outdated version of bitcoind `"subversion": "/Satoshi:0.13.2/"`.  I'm happy to push these updates into `Dockerfile` as well, or simply rename `Docker.web` as `Docker`.  The downside to compiling bitcoind from source in the container is the initial build process can take a while, so it may be prefered to include a static binary instead depending on the "thickness of your tin foil hat :)".

