### PR TITLE
fix bad iteration in finish_batch certificate_handlers.py

### DIFF
--- a/cert_issuer/certificate_handlers.py
+++ b/cert_issuer/certificate_handlers.py
@@ -121,7 +121,7 @@ class CertificateBatchHandler(BatchHandler):
 
     def finish_batch(self, tx_id, chain):
         proof_generator = self.merkle_tree.get_proof_generator(tx_id, chain)
-        for metadata in self.certificates_to_issue.items():
+        for _, metadata in self.certificates_to_issue.items():
             proof = next(proof_generator)
             self.certificate_handler.add_proof(metadata, proof)
 

--- a/tests/test_certificate_handler.py
+++ b/tests/test_certificate_handler.py
@@ -16,13 +16,13 @@ class TestCertificateHandler(unittest.TestCase):
         proof = {
                 'merkleRoot': '0932f1d2e98219f7d7452801e2b64ebd9e5c005539db12d9b1ddabe7834d9044',
                 'type': ['MerkleProof2017', 'Extension'],
-		'targetHash': ANY,
+        'targetHash': ANY,
                 'anchors': [
-			{
-			    'sourceId': ANY,
-			    'type': chain.blockchain_type.external_display_value,
-			    'chain': chain.external_display_value
-			}
+            {
+                'sourceId': ANY,
+                'type': chain.blockchain_type.external_display_value,
+                'chain': chain.external_display_value
+            }
                     ],
                 'proof': [
                     {'right': 'd4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35'},
@@ -130,10 +130,10 @@ class TestCertificateHandler(unittest.TestCase):
         proof, proof_1, proof_2 = self._proof_helper(chain)
 
         with patch.object(DummyCertificateHandler, 'add_proof', return_value= {"cert": "cert"} ) as mock_method:
-	    result = certificate_batch_handler.finish_batch(
-                    '5604f0c442922b5db54b69f8f363b3eac67835d36a006b98e8727f83b6a830c0', chain
-                    )
-	self.assertEqual(certificate_batch_handler.proof, [{'cert': 'cert'}, {'cert': 'cert'}, {'cert': 'cert'}])
+            result = certificate_batch_handler.finish_batch(
+                        '5604f0c442922b5db54b69f8f363b3eac67835d36a006b98e8727f83b6a830c0', chain
+                        )
+        self.assertEqual(certificate_batch_handler.proof, [{'cert': 'cert'}, {'cert': 'cert'}, {'cert': 'cert'}])
         mock_method.assert_any_call(ANY, proof)
         mock_method.assert_any_call(ANY, proof_1)
         mock_method.assert_any_call(ANY, proof_2)
@@ -194,35 +194,35 @@ class TestCertificateHandler(unittest.TestCase):
 
         assert not mock_method.called
 
-    @mock.patch("__builtin__.open", create=True)
+    @mock.patch("builtins.open", create=True)
     def test_add_proof(self,mock_open):
         handler = CertificateV2Handler()
 
-	cert_to_issue = {'kek':'kek'}
-	proof = {'a': 'merkel'}
-	file_call = 'call().__enter__().write(\'{"kek": "kek", "signature": {"a": "merkel"}}\')'
+        cert_to_issue = {'kek':'kek'}
+        proof = {'a': 'merkel'}
+        file_call = 'call().__enter__().write(\'{"kek": "kek", "signature": {"a": "merkel"}}\')'
 
         chain = mock.Mock()
         metadata = mock.Mock()
-	metadata.blockchain_cert_file_name = 'file_path.nfo'
+        metadata.blockchain_cert_file_name = 'file_path.nfo'
 
         with patch.object(
-		CertificateV2Handler, '_get_certificate_to_issue', return_value=cert_to_issue) as mock_method:
-            handler.add_proof(metadata, proof)
+        CertificateV2Handler, '_get_certificate_to_issue', return_value=cert_to_issue) as mock_method:
+                handler.add_proof(metadata, proof)
 
-	mock_open.assert_any_call('file_path.nfo','w')
-	calls = mock_open.mock_calls
-	call_strings = map(str, calls)
-	assert file_call in call_strings
+        mock_open.assert_any_call('file_path.nfo','w')
+        calls = mock_open.mock_calls
+        call_strings = map(str, calls)
+        assert file_call in call_strings
 
     def test_web_add_proof(self):
-	handler = CertificateWebV2Handler()
-	proof = {'a': 'merkel'}
-	chain = mock.Mock()
-	certificate_json = {'kek': 'kek'}
+        handler = CertificateWebV2Handler()
+        proof = {'a': 'merkel'}
+        chain = mock.Mock()
+        certificate_json = {'kek': 'kek'}
 
-	return_cert = handler.add_proof(certificate_json, proof)
-	self.assertEqual(return_cert, {'kek':'kek', 'signature': {'a': 'merkel'}})
+        return_cert = handler.add_proof(certificate_json, proof)
+        self.assertEqual(return_cert, {'kek':'kek', 'signature': {'a': 'merkel'}})
 
 class DummyCertificateHandler(CertificateHandler):
     def __init__(self):


### PR DESCRIPTION
I run the demo as quick start described, however get an error:
```
ab987a087865:/etc/cert-issuer# cert-issuer -c /etc/cert-issuer/conf.ini
WARNING - Your app is configured to skip the wifi check when the USB is plugged in. Read the documentation to ensure this is what you want, since this is less secure
INFO - This run will try to issue on the bitcoin_regtest chain
INFO - Set cost constants to recommended_tx_fee=0.000600,min_per_output=0.000028,satoshi_per_byte=250
INFO - Processing 1 certificates
INFO - Processing 1 certificates under work path=/etc/cert-issuer/work
INFO - Total cost will be 133500 satoshis
INFO - Starting finalizable signer
WARNING - app is configured to skip the wifi check when the USB is plugged in. Read the documentation to ensure this is what you want, since this is less secure
INFO - Stopping finalizable signer
WARNING - app is configured to skip the wifi check when the USB is plugged in. Read the documentation to ensure this is what you want, since this is less secure
INFO - here is the op_return_code data: c65c6184e3d5a945ddb5437e93ea312411fd33aa1def22b0746d6ecd4aa30f20
INFO - Unsigned hextx=0100000001e862aefcfcabe00e7552b3d7b5b1f2000a66ea90b02581bc6338436dabdd757f0000000000ffffffff028068c21d000000001976a914effebb7d38501a55f6dc4352b9a27ca6643582e888ac0000000000000000226a20c65c6184e3d5a945ddb5437e93ea312411fd33aa1def22b0746d6ecd4aa30f2000000000
INFO - Preparing tx for signing
INFO - Starting finalizable signer
WARNING - app is configured to skip the wifi check when the USB is plugged in. Read the documentation to ensure this is what you want, since this is less secure
INFO - Stopping finalizable signer
WARNING - app is configured to skip the wifi check when the USB is plugged in. Read the documentation to ensure this is what you want, since this is less secure
INFO - The actual transaction size is 235 bytes
INFO - Signed hextx=0100000001e862aefcfcabe00e7552b3d7b5b1f2000a66ea90b02581bc6338436dabdd757f000000006b48304502210096a3b426b0d17a105cc1efd44d8d45b235ec0d862033c8c135c694a9a0b8e92302201a1f94a47faa76619c143e627ba5114e379d90ec0bdcfa53a4ae9b0086c1f004012103f4e1b15d91e18c157eaa1624f185bb6aef3d9181c9b55181556956cdbb7854b7ffffffff028068c21d000000001976a914effebb7d38501a55f6dc4352b9a27ca6643582e888ac0000000000000000
226a20c65c6184e3d5a945ddb5437e93ea312411fd33aa1def22b0746d6ecd4aa30f2000000000
INFO - Signed hextx=0100000001e862aefcfcabe00e7552b3d7b5b1f2000a66ea90b02581bc6338436dabdd757f000000006b48304502210096a3b426b0d17a105cc1efd44d8d45b235ec0d862033c8c135c694a9a0b8e92302201a1f94a47faa76619c143e627ba5114e379d90ec0bdcfa53a4ae9b0086c1f004012103f4e1b15d91e18c157eaa1624f185bb6aef3d9181c9b55181556956cdbb7854b7ffffffff028068c21d000000001976a914effebb7d38501a55f6dc4352b9a27ca6643582e888ac0000000000000000
226a20c65c6184e3d5a945ddb5437e93ea312411fd33aa1def22b0746d6ecd4aa30f2000000000
INFO - verifying op_return value for transaction
INFO - verified OP_RETURN
INFO - Broadcasting succeeded with method_provider=<bound method BitcoindConnector.broadcast_tx of <cert_issuer.blockchain_handlers.bitcoin.connectors.BitcoindConnector object at 0x7f3d0b924a58>>, txid=ebe8a3910a0f4519402eab04d39182edbadd4f6ef42e3183c270613fc6854faf
Traceback (most recent call last):
  File "/usr/bin/cert-issuer", line 11, in <module>
    load_entry_point('cert-issuer==2.0.15', 'console_scripts', 'cert-issuer')()
  File "/usr/lib/python3.6/site-packages/cert_issuer/__main__.py", line 17, in cert_issuer_main
    issue_certificates.main(parsed_config)
  File "/usr/lib/python3.6/site-packages/cert_issuer/issue_certificates.py", line 36, in main
    return issue(app_config, certificate_batch_handler, transaction_handler)
  File "/usr/lib/python3.6/site-packages/cert_issuer/issue_certificates.py", line 22, in issue
    tx_id = issuer.issue(app_config.chain)
  File "/usr/lib/python3.6/site-packages/cert_issuer/issuer.py", line 28, in issue
    self.certificate_batch_handler.finish_batch(txid, chain)
  File "/usr/lib/python3.6/site-packages/cert_issuer/certificate_handlers.py", line 126, in finish_batch
    self.certificate_handler.add_proof(metadata, proof)
  File "/usr/lib/python3.6/site-packages/cert_issuer/certificate_handlers.py", line 24, in add_proof
    certificate_json = self._get_certificate_to_issue(certificate_metadata)
  File "/usr/lib/python3.6/site-packages/cert_issuer/certificate_handlers.py", line 30, in _get_certificate_to_issue
    with open(certificate_metadata.unsigned_cert_file_name, 'r') as unsigned_cert_file:
AttributeError: 'tuple' object has no attribute 'unsigned_cert_file_name'
```
same problem: [https://community.blockcerts.org/t/error-of-cert-issuer-c-etc-cert-issuer-conf-ini/1643](https://community.blockcerts.org/t/error-of-cert-issuer-c-etc-cert-issuer-conf-ini/1643)

It seems that the problem is caused by this [line](https://github.com/blockchain-certificates/cert-issuer/commit/f7d0f238fbaa022f216dfccf8bf792060d97faf2#diff-69f833dd6b77ead01abdebddd7dfc216R124), which is a bad iteration, bring in by #121. 

