### PR TITLE
Create a separate page for describing web services

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 maintainer yancy ribbens "yribbens@credly.com"
 
-RUN apt-get update -qq && apt-get install -y git wget build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3 libboost-all-dev libminiupnpc-dev libzmq3-dev python3-pip locales vim python3.6 python3.6-dev uwsgi uwsgi-src uuid-dev libcap-dev libpcre3-dev python-pip python-dev nginx
+RUN apt-get update -qq && apt-get install -y git wget build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3 libboost-all-dev libminiupnpc-dev libzmq3-dev python3-pip locales vim python3.6 python3.6-dev uwsgi uwsgi-src uuid-dev libcap-dev libpcre3-dev python-pip python-dev nginx netcat
 
 # Checkout bitcoin source
 RUN mkdir /bitcoin-source
@@ -66,4 +66,5 @@ COPY cert_issuer_site /etc/nginx/sites-available
 RUN ln -s /etc/nginx/sites-available/cert_issuer_site /etc/nginx/sites-enabled
 RUN sed -i.bak "s/<server-name>/$SERVER/g" /etc/nginx/sites-available/cert_issuer_site
 RUN sed -i.bak "s/# server_names_hash_bucket_size 64/server_names_hash_bucket_size 128/g" /etc/nginx/nginx.conf
+RUN chmod +x start-cert-issuer.sh
 ENTRYPOINT bitcoind -daemon && service nginx start && uwsgi --ini wsgi.ini

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 The cert-issuer project issues blockchain certificates by creating a transaction from the issuing institution to the
 recipient on the Bitcoin blockchain that includes the hash of the certificate itself. 
 
+## Web resources
+For development or testing using web requests, check out the documentation at [docs/web_resources.md](./docs/web_resources.md).
+
 # Quick start using Docker
 
 ## Getting the Docker image
@@ -28,26 +31,6 @@ experimenting only.
     docker build -t bc/cert-issuer:1.0 .
     ```
 
-    Optionally, the following image can built which is web-enabled.  This will expose port 80 inside the container and receive web requests, passing each requests to cert_issuer.
-
-    ```
-    docker build -t bc/cert-issuer:1.0 -f Dockerfile.web .
-    ```
-
-    Additionally, build args can be passed to the container at build time, for example:
-    ```
-    docker build -t bc/cert-issuer:1.0 -f Dockerfile.web . --build-arg NETWORK=testnet --build-arg SERVER=ec2-31-415-59-265.us-west-1.compute.amazonaws.com
-    ```
-
-    The list of build-args and the default values are as follows:
-    ```
-    NETWORK=regtest 
-    RPC_USER=foo
-    RPC_PASSWORD=bar
-    ISSUER=<issuing-address>
-    SERVER=<server-name>
-    ```
-
 4. Read before running!
 
     - Once you launch the docker container, you will make some changes using your personal issuing information. This flow mirrors what you would if you were issuing real certificates.
@@ -62,19 +45,6 @@ experimenting only.
 
     ```
     docker run -it bc/cert-issuer:1.0 bash
-    ```
-
-    If you built the web container, you'll need to expose the required ports at run time:
-
-
-    ```
-    sudo docker run -it -p 80:80 bc/cert-issuer:1.0
-    ```
-
-    to create a named volume to persist the blockchain state across the container lifespan:
-
-    ```
-    sudo docker run -it -v cert-issuer:/root/.bitcoin -p 80:80 bc/cert-issuer:1.0
     ```
 
 ## Create issuing address
@@ -105,14 +75,6 @@ Ensure your docker image is running and bitcoind process is started
     # If you created your own unsigned certificate using cert-tools (assuming you placed it under data/unsigned_certificates):
     cp <cert-issuer-home>/data/unsigned_certificates/<your-cert-guid>.json /etc/cert-issuer/data/unsigned_certificates/
     ```
-
-    Alternatively, if the web image was build, a post request can be issued.  Please read the additonal instructions for configuring the web server.
-
-    ```
-    POST http://<server address>/cert_issuer/api/v1.0/issue
-    ```
-
-    The above post request will return a JSON signature that can be used as proof of issuance.
 
 2. Make sure you have enough BTC in your issuing address.
 

--- a/docs/web_resources.md
+++ b/docs/web_resources.md
@@ -1,0 +1,63 @@
+## Web Resources
+
+This document describes how to run a web service which accepts web requests over port 80 (HTTP).
+
+## HTTP Docker setup
+
+To build a cert-issuer that accepts web requests, run the following command and substitute www.example.com
+ with your domain name.  The name you substitute is used by the Nginx server block to match request domains.
+
+```
+sudo docker build . -t bc/cert-issuer-http:1.0 -f Dockerfile.web \
+--build-arg NETWORK=regtest \
+--build-arg SERVER=www.example.com
+```
+
+Once the build is complete, start the web service:
+
+```
+sudo docker run -it --entrypoint "/cert-issuer/start-cert-issuer.sh" -p 80:80 bc/cert-issuer-http:1.0
+```
+
+Web requests can now be sent with `POST`.
+
+Example Request:
+```
+POST http://example.com/cert_issuer/api/v1.0/issue
+```
+
+Example Payload:
+```
+[
+    { "cert": "cert data" },
+    { "cert1": "more certs"},
+    { "cert2": "certs for days"}
+]
+```
+
+## Extended HTTP/HTTPS Docker setup
+
+A named volume is useful for persisting chain state, for example:
+```
+sudo docker run -it -v cert-issuer:/root/.bitcoin -p 80:80 bc/cert-issuer:1.0
+```
+
+Also, a Dockerfile is provided for sending requests with TLS using `Dockerfile.web.tls` for implementations beyond reg_test
+
+Build HTTPS docker image:
+```
+sudo docker build -t bc/cert-issuer-https:1.0  \
+-f Dockerfile.web.tls . --build-arg NETWORK=testnet \
+--build-arg SERVER=www.example.com --build-arg RPC_USER=j0hnny \
+--build-arg RPC_PASSWORD=mn3m0nic \
+--build-arg ISSUER=legacy_address \
+--build-arg CRT=file.crt \
+--build-arg KEY=file.key
+```
+
+Launch HTTPS docker container:
+```
+sudo docker run -it -p 443:443 bc/cert-issuer-https:1.0
+```
+
+Happy hacking =]

--- a/start-cert-issuer.sh
+++ b/start-cert-issuer.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# exit from script if error was raised.
+set -e
+
+# start the bitcoin service
+bitcoind -daemon
+
+# wait for bitcoind to start accepting connections
+while ! nc -z localhost 8332 </dev/null; do sleep 10; done
+
+# Create an issuing address and save the output
+ISSUER=$(bitcoin-cli getnewaddress "" legacy)
+sed -i.bak "s/<issuing-address>/$ISSUER/g" /etc/cert-issuer/conf.ini
+KEY="$(bitcoin-cli dumpprivkey $ISSUER)"
+echo $KEY > /etc/cert-issuer/pk_issuer.txt
+
+# advance network
+bitcoin-cli generate 101
+
+# send btc to issuer address
+bitcoin-cli sendtoaddress $ISSUER 5
+
+# start web service
+service nginx start && uwsgi --ini wsgi.ini


### PR DESCRIPTION
This PR creates a separate page for describing setting up and testing the cert-issuer web and creates a link from the main README.  I also added a file `start-cert-issuer.sh` which can be used to streamline testing by overriding the docker entrypoint described in the docs.