### PR TITLE
Lock pycoin version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ configargparse==0.12.0
 glob2==0.6
 mock==2.0.0
 requests[security]>=2.18.4
-pycoin>=0.80
+pycoin==0.80
 pyld>=1.0.3
 pysha3>=1.0.2
 python-bitcoinlib>=0.10.1


### PR DESCRIPTION
Pycoin  v0.90 came almost 2 years after v0.80, and this latest version introduces a lot of non-backwards compatible changes:
- `b2h`, `h2b` `h2b_rev` and `b2h_rev` were moved from `serialize` to `encoding.hexbytes`
- `Spendable` was moved from `tx.Spendable` to `coins.bitcoin.Tx`
...and many more changes.

This version lock prevents `cert-issuer` from breaking.