### PR TITLE
fix: update new web location of Merkleproof-2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Suppose the batch contains `n` certificates, and certificate `i` contains recipi
 
 The root of the Merkle tree, which is a 256-bit hash, is issued on the Bitcoin blockchain. The complete Bitcoin transaction outputs are described in 'Transaction structure'.
 
-The Blockchain Certificate given to recipient `i` contains a [2017 Merkle Proof Signature Suite](https://w3c-dvcg.github.io/lds-merkleproof2017/)-formatted signature, proving that certificate `i` is contained in the Merkle tree.
+The Blockchain Certificate given to recipient `i` contains a [2017 Merkle Proof Signature Suite](https://w3c-ccg.github.io/lds-merkleproof2017/)-formatted signature, proving that certificate `i` is contained in the Merkle tree.
 
 ![](img/blockchain_certificate_components.png)
 


### PR DESCRIPTION
Changing to the new location of Merkleproof-2017 from https://w3c-dvcg.github.io/lds-merkleproof2017/ to https://w3c-ccg.github.io/lds-merkleproof2017/