### PR TITLE
Move to a more updated image for bitcoind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM seegno/bitcoind:0.13-alpine
+FROM lncm/bitcoind:v22.0
 MAINTAINER Kim Duffy "kimhd@mit.edu"
+
+USER root
 
 COPY . /cert-issuer
 COPY conf_regtest.ini /etc/cert-issuer/conf.ini
@@ -17,7 +19,7 @@ RUN apk add --update \
         linux-headers \
         make \
         musl-dev \
-        python \
+        python2 \
         python3 \
         python3-dev \
         tar \


### PR DESCRIPTION
this will also support more architectures (like Apple M1 ones)

this will fix https://github.com/blockchain-certificates/cert-issuer/issues/221