### PR TITLE
Correct the dead link of Merkle Proof Signature Suite 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Suppose the batch contains `n` certificates, and certificate `i` contains recipi
 
 The root of the Merkle tree, which is a 256-bit hash, is issued on the Bitcoin blockchain. The complete Bitcoin transaction outputs are described in 'Transaction structure'.
 
-The Blockchain Certificate given to recipient `i` contains a [2019 Merkle Proof Signature Suite](https://w3c-ccg.github.io/lds-merkleproof2019/)-formatted proof, proving that certificate `i` is contained in the Merkle tree.
+The Blockchain Certificate given to recipient `i` contains a [2019 Merkle Proof Signature Suite](https://w3c-ccg.github.io/lds-merkle-proof-2019/)-formatted proof, proving that certificate `i` is contained in the Merkle tree.
 
 ![](img/blockchain_certificate_components.png)
 


### PR DESCRIPTION
Hi, Blockcerts maintainers
I found a dead link, so I corrected it.
Could you check this?
