### PR TITLE
Support Ethereum testnets, the Goerli and the Sepolia

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ issuing_address = <issuing-address>
 # issuer URL / DID
 verification_method = <verification-method>
 
-chain=<bitcoin_regtest|bitcoin_testnet|bitcoin_mainnet|ethereum_ropsten|ethereum_mainnet|mockchain>
+chain=<bitcoin_regtest|bitcoin_testnet|bitcoin_mainnet|ethereum_goerli|ethereum_sepolia|ethereum_ropsten|ethereum_mainnet|mockchain>
 
 usb_name = </Volumes/path-to-usb/>
 key_file = <file-you-saved-pk-to>
@@ -380,7 +380,7 @@ python cert-issuer -c conf.ini
 - The Blockchain Certificates will be located in data/blockchain_certificates.
 - If you ran in the mainnet or testnet mode, you can also see your transaction on a live blockchain explorer.
   - For Bitcoin, Blockchain.com has explorers for both [testnet](https://www.blockchain.com/explorer?view=btc-testnet) and [mainnet](https://www.blockchain.com/explorer?view=btc).
-  - For Ethereum, Etherscan has explorers for [ropsten](https://ropsten.etherscan.io/) and [mainnet](https://etherscan.io/)
+  - For Ethereum, Etherscan has explorers for [goerli](https://goerli.etherscan.io/), [sepolia](https://sepolia.etherscan.io/), [ropsten](https://ropsten.etherscan.io/) and [mainnet](https://etherscan.io/)
   - The transaction id is located in the Blockchain Certificate under `signature.anchors[0].sourceId`
 
 # Contributing
@@ -409,6 +409,8 @@ For an Ethereum transaction, you'll need to use a different explorer, which migh
 output. To view a transaction in a web browser, you might try something like this:
 
 - Ethereum Mainnet: https://etherscan.io/tx/0xf537d81667c8011e34e1f450e18fd1c5a8a10c770cd0acdc91a79746696f36a3
+- Ethereum Goerli (testnet): https://goerli.etherscan.io/tx/0xfb593f186a274f58f861e5186150bc692ed533c7af50efb094f756ccb81c7023
+- Ethereum Sepolia (testnet): https://sepolia.etherscan.io/tx/0xa5484369839ba54cd3be71271155fc1a76b52499607dcddbf682ee04534a3f95
 - Ethereum Ropsten (testnet): https://ropsten.etherscan.io/tx/0xf537d81667c8011e34e1f450e18fd1c5a8a10c770cd0acdc91a79746696f36a3
 
 ## Mac scrypt problems

--- a/cert_issuer/blockchain_handlers/bitcoin/__init__.py
+++ b/cert_issuer/blockchain_handlers/bitcoin/__init__.py
@@ -1,8 +1,7 @@
 import logging
 import os
 
-from cert_core import BlockchainType
-from cert_core import Chain, UnknownChainError
+from cert_core import UnknownChainError
 
 from cert_issuer.blockchain_handlers.bitcoin.connectors import BitcoinServiceProviderConnector, MockServiceProviderConnector
 from cert_issuer.blockchain_handlers.bitcoin.signer import BitcoinSigner
@@ -33,9 +32,9 @@ class BitcoinTransactionCostConstants(object):
 def initialize_signer(app_config):
     path_to_secret = os.path.join(app_config.usb_name, app_config.key_file)
 
-    if app_config.chain.blockchain_type == BlockchainType.bitcoin:
+    if app_config.chain.is_bitcoin_type():
         signer = BitcoinSigner(bitcoin_chain=app_config.chain)
-    elif app_config.chain == Chain.mockchain:
+    elif app_config.chain.is_mock_type():
         signer = None
     else:
         raise UnknownChainError(app_config.chain)
@@ -58,7 +57,7 @@ def instantiate_blockchain_handlers(app_config, file_mode=True):
                                                                certificate_handler=CertificateWebV3Handler(),
                                                                merkle_tree=MerkleTreeGenerator(),
                                                                config=app_config)
-    if chain == Chain.mockchain:
+    if chain.is_mock_type():
         transaction_handler = MockTransactionHandler()
         connector = MockServiceProviderConnector()
     else:

--- a/cert_issuer/blockchain_handlers/ethereum/__init__.py
+++ b/cert_issuer/blockchain_handlers/ethereum/__init__.py
@@ -60,7 +60,7 @@ def instantiate_blockchain_handlers(app_config):
     if chain == Chain.mockchain:
         transaction_handler = MockTransactionHandler()
     # ethereum chains
-    elif chain == Chain.ethereum_mainnet or chain == Chain.ethereum_ropsten:
+    elif chain == Chain.ethereum_mainnet or chain == Chain.ethereum_ropsten or chain == Chain.ethereum_goerli or chain == Chain.ethereum_sepolia:
         cost_constants = EthereumTransactionCostConstants(app_config.gas_price, app_config.gas_limit)
         connector = EthereumServiceProviderConnector(chain, app_config)
         transaction_handler = EthereumTransactionHandler(connector, cost_constants, secret_manager,

--- a/cert_issuer/blockchain_handlers/ethereum/__init__.py
+++ b/cert_issuer/blockchain_handlers/ethereum/__init__.py
@@ -1,8 +1,7 @@
 import logging
 import os
 
-from cert_core import BlockchainType
-from cert_core import Chain, UnknownChainError
+from cert_core import UnknownChainError
 
 from cert_issuer.certificate_handlers import CertificateBatchHandler, CertificateV3Handler
 from cert_issuer.blockchain_handlers.ethereum.connectors import EthereumServiceProviderConnector
@@ -38,9 +37,9 @@ class EthereumTransactionCostConstants(object):
 def initialize_signer(app_config):
     path_to_secret = os.path.join(app_config.usb_name, app_config.key_file)
 
-    if app_config.chain.blockchain_type == BlockchainType.ethereum:
+    if app_config.chain.is_ethereum_type():
         signer = EthereumSigner(ethereum_chain=app_config.chain)
-    elif app_config.chain == Chain.mockchain:
+    elif app_config.is_mock_type():
         signer = None
     else:
         raise UnknownChainError(app_config.chain)
@@ -57,10 +56,10 @@ def instantiate_blockchain_handlers(app_config):
                                                         certificate_handler=CertificateV3Handler(),
                                                         merkle_tree=MerkleTreeGenerator(),
                                                         config=app_config)
-    if chain == Chain.mockchain:
+    if chain.is_mock_type():
         transaction_handler = MockTransactionHandler()
     # ethereum chains
-    elif chain == Chain.ethereum_mainnet or chain == Chain.ethereum_ropsten or chain == Chain.ethereum_goerli or chain == Chain.ethereum_sepolia:
+    elif chain.is_ethereum_type():
         cost_constants = EthereumTransactionCostConstants(app_config.gas_price, app_config.gas_limit)
         connector = EthereumServiceProviderConnector(chain, app_config)
         transaction_handler = EthereumTransactionHandler(connector, cost_constants, secret_manager,

--- a/cert_issuer/blockchain_handlers/ethereum/connectors.py
+++ b/cert_issuer/blockchain_handlers/ethereum/connectors.py
@@ -59,6 +59,22 @@ class EthereumServiceProviderConnector(ServiceProviderConnector):
         # rop_provider_list.append(MyEtherWalletBroadcaster('https://api.myetherwallet.com/rop', None))
         self.connectors[Chain.ethereum_ropsten] = rop_provider_list
 
+        # Configure Ethereum Goerli testnet connectors
+        goe_provider_list = []
+        if hasattr(app_config, 'goerli_rpc_url'):
+            self.goerli_rpc_url = app_config.goerli_rpc_url
+            goe_provider_list.append(EthereumRPCProvider(self.goerli_rpc_url))
+        goe_provider_list.append(EtherscanBroadcaster('https://api-goerli.etherscan.io/api', etherscan_api_token))
+        self.connectors[Chain.ethereum_goerli] = goe_provider_list
+
+        # Configure Ethereum Sepolia testnet connectors
+        sep_provider_list = []
+        if hasattr(app_config, 'sepolia_rpc_url'):
+            self.sepolia_rpc_url = app_config.sepolia_rpc_url
+            sep_provider_list.append(EthereumRPCProvider(self.sepolia_rpc_url))
+        sep_provider_list.append(EtherscanBroadcaster('https://api-sepolia.etherscan.io/api', etherscan_api_token))
+        self.connectors[Chain.ethereum_sepolia] = sep_provider_list
+
     def get_providers_for_chain(self, chain, local_node=False):
         return self.connectors[chain]
 

--- a/cert_issuer/blockchain_handlers/ethereum/signer.py
+++ b/cert_issuer/blockchain_handlers/ethereum/signer.py
@@ -14,6 +14,10 @@ class EthereumSigner(Signer):
             self.netcode = 1
         elif ethereum_chain.external_display_value == 'ethereumRopsten':
             self.netcode = 3
+        elif ethereum_chain.external_display_value == 'ethereumGoerli':
+            self.netcode = 5
+        elif ethereum_chain.external_display_value == 'ethereumSepolia':
+            self.netcode = 11155111
         else:
             self.netcode = None
 

--- a/cert_issuer/config.py
+++ b/cert_issuer/config.py
@@ -49,7 +49,7 @@ def add_arguments(p):
     p.add_argument('--max_retry', default=10, type=int, help='Maximum attempts to retry transaction on failure', env_var='MAX_RETRY')
     p.add_argument('--chain', default='bitcoin_regtest',
                    help=('Which chain to use. Default is bitcoin_regtest (which is how the docker container is configured). Other options are '
-                         'bitcoin_testnet bitcoin_mainnet, mockchain, ethereum_mainnet, ethereum_ropsten'), env_var='CHAIN')
+                         'bitcoin_testnet bitcoin_mainnet, mockchain, ethereum_mainnet, ethereum_ropsten, ethereum_goerli, ethereum_sepolia'), env_var='CHAIN')
 
     p.add_argument('--safe_mode', dest='safe_mode', default=True, action='store_true',
                    help='Used to make sure your private key is not plugged in with the wifi.', env_var='SAFE_MODE')
@@ -81,6 +81,12 @@ def add_arguments(p):
     p.add_argument('--ropsten_rpc_url', default=None, type=str,
                    help='The URL of an Ethereum Ropsten RPC node - useful in the case of third-party full node vendors.',
                    env_var='ROPSTEN_RPC_URL')
+    p.add_argument('--goerli_rpc_url', default=None, type=str,
+                   help='The URL of an Ethereum Goerli RPC node - useful in the case of third-party full node vendors.',
+                   env_var='GOERLI_RPC_URL')
+    p.add_argument('--sepolia_rpc_url', default=None, type=str,
+                   help='The URL of an Ethereum Sepolia RPC node - useful in the case of third-party full node vendors.',
+                   env_var='SEPOLIA_RPC_URL')
 
     p.add_argument('--blockcypher_api_token', default=None, type=str,
                    help='the API token of the blockcypher broadcaster', env_var='BLOCKCYPHER_API_TOKEN')

--- a/cert_issuer/helpers.py
+++ b/cert_issuer/helpers.py
@@ -111,6 +111,10 @@ def tx_to_blink(chain, tx_id):
         blink += 'btc:mainnet:'
     elif chain == Chain.ethereum_ropsten:
         blink += 'eth:ropsten:'
+    elif chain == Chain.ethereum_goerli:
+        blink += 'eth:goerli:'
+    elif chain == Chain.ethereum_sepolia:
+        blink += 'eth:sepolia:'
     elif chain == Chain.ethereum_mainnet:
         blink += 'eth:mainnet:'
     elif chain == Chain.mockchain:

--- a/cert_issuer/issue_certificates.py
+++ b/cert_issuer/issue_certificates.py
@@ -1,8 +1,6 @@
 import logging
 import sys
 
-from cert_core import Chain
-
 from cert_issuer.issuer import Issuer
 
 if sys.version_info.major < 3:
@@ -27,7 +25,7 @@ def issue(app_config, certificate_batch_handler, transaction_handler):
 
 def main(app_config):
     chain = app_config.chain
-    if chain == Chain.ethereum_mainnet or chain == Chain.ethereum_ropsten or chain == Chain.ethereum_goerli or chain == Chain.ethereum_sepolia:
+    if chain.is_ethereum_type():
         from cert_issuer.blockchain_handlers import ethereum
         certificate_batch_handler, transaction_handler, connector = ethereum.instantiate_blockchain_handlers(app_config)
     else:

--- a/cert_issuer/issue_certificates.py
+++ b/cert_issuer/issue_certificates.py
@@ -27,7 +27,7 @@ def issue(app_config, certificate_batch_handler, transaction_handler):
 
 def main(app_config):
     chain = app_config.chain
-    if chain == Chain.ethereum_mainnet or chain == Chain.ethereum_ropsten:
+    if chain == Chain.ethereum_mainnet or chain == Chain.ethereum_ropsten or chain == Chain.ethereum_goerli or chain == Chain.ethereum_sepolia:
         from cert_issuer.blockchain_handlers import ethereum
         certificate_batch_handler, transaction_handler, connector = ethereum.instantiate_blockchain_handlers(app_config)
     else:

--- a/cert_issuer/merkle_tree_generator.py
+++ b/cert_issuer/merkle_tree_generator.py
@@ -86,7 +86,7 @@ class MerkleTreeGenerator(object):
 
 
 def to_source_id(txid, chain):
-    if chain == Chain.bitcoin_mainnet or Chain.bitcoin_testnet or Chain.ethereum_mainnet or Chain.ethereum_ropsten:
+    if chain == Chain.bitcoin_mainnet or Chain.bitcoin_testnet or Chain.ethereum_mainnet or Chain.ethereum_ropsten or Chain.ethereum_goerli or Chain.ethereum_sepolia:
         return txid
     else:
         return 'This has not been issued on a blockchain and is for testing only'

--- a/cert_issuer/merkle_tree_generator.py
+++ b/cert_issuer/merkle_tree_generator.py
@@ -86,7 +86,7 @@ class MerkleTreeGenerator(object):
 
 
 def to_source_id(txid, chain):
-    if chain == Chain.bitcoin_mainnet or Chain.bitcoin_testnet or Chain.ethereum_mainnet or Chain.ethereum_ropsten or Chain.ethereum_goerli or Chain.ethereum_sepolia:
+    if chain.is_bitcoin_type() or chain.is_ethereum_type():
         return txid
     else:
         return 'This has not been issued on a blockchain and is for testing only'

--- a/conf_ethtest.ini
+++ b/conf_ethtest.ini
@@ -1,6 +1,6 @@
 issuing_address = <Your Ethereum address> 
 
-chain = <ethereum_ropsten|ethereum_mainnet>
+chain = <ethereum_goerli|ethereum_sepolia|ethereum_ropsten|ethereum_mainnet>
 
 usb_name=</Volumes/path-to-usb/>
 key_file=<file-you-saved-pk-to>

--- a/docs/ethereum_configuration.md
+++ b/docs/ethereum_configuration.md
@@ -8,5 +8,7 @@ This should hold the Hex string of the BIP32 derived private key, generated from
 ## conf.ini
 ```
 issuing_address=0xYOUR_ADDRESS # matching with the private key above
-chain=ethereum_ropsten # one of ['ethereum_ropsten', 'ethereum_mainnet']
+chain=ethereum_goerli # one of ['ethereum_goerli', 'ethereum_sepolia', 'ethereum_ropsten', 'ethereum_mainnet']
 ```
+
+`ethereum_ropsten` is DEPRECATED because the Ropsten has been announced to close in Q4 2022.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cert-core>=3.0.0b1
+cert-core>=3.0.0
 cert-schema>=3.2.1
 merkletools==1.0.3
 configargparse==0.12.0
@@ -11,4 +11,4 @@ pysha3>=1.0.2
 python-bitcoinlib>=0.10.1
 tox>=3.0.0
 jsonschema<3.0.0
-lds-merkle-proof-2019>=0.0.2
+lds-merkle-proof-2019>=0.1.0


### PR DESCRIPTION
Hi maintainers,

This PR is to allow using Ethereum testnets, the Goerli and the Sepolia.
We have discussed this on [this forum page](https://community.blockcerts.org/t/ethereum-announced-the-testnet-ropsten-would-be-closed-in-q4-2022/3227).
Could you check this?

# Test

After set to use the related changed [cert-core](https://github.com/blockchain-certificates/cert-core/pull/4) and [lds-merkle-proof-2019-py](https://github.com/blockchain-certificates/lds-merkle-proof-2019-py/pull/4), I confirmed the following cases:

- Goeril
  - it issues a VC and saves the transaction on Goerli ([Actual Transaction](https://goerli.etherscan.io/tx/0xfb593f186a274f58f861e5186150bc692ed533c7af50efb094f756ccb81c7023))
  - it issues a VC and saves the transaction on Goerli with env:`GOERLI_RPC_URL` set `https://goerli.prylabs.net/`
- Sepolia 
  - it issues a VC and saves the transaction on Sepolia ([Actual Transaction](https://sepolia.etherscan.io/tx/0xa5484369839ba54cd3be71271155fc1a76b52499607dcddbf682ee04534a3f95))
  - it issues a VC and saves the transaction on Sepolia with env:`SEPOLIA_RPC_URL` set `https://rpc.sepolia.dev/`
- Ropsten (for checking degrade)
  -  it issues a VC and saves the transaction on Ropsten ([Actual Transaction](https://ropsten.etherscan.io/tx/0x86b8f9aafb1874f9cfc559649b049acc69a38544d4397f7cb98fb98af935783c))

And then, I updated the [cert-verifier-js#1393](https://github.com/blockchain-certificates/cert-verifier-js/pull/1393) and the generated VCs could be verified.

# Tasks

If you approve this, I think we need to do the below tasks.

- https://github.com/blockchain-certificates/cert-core/pull/4
  - [x] merge and release a new package
- https://github.com/blockchain-certificates/lds-merkle-proof-2019-py/pull/4
  - [x] merge and release a new package
- [x] update the dependencies to use the new packages, `cert-core` and `lds-merkle-proof-2019-py`