### PR TITLE
Enable EIP-1559 ETH txs and update deprecated web3 methods/packages

### DIFF
--- a/cert_issuer/blockchain_handlers/ethereum/connectors.py
+++ b/cert_issuer/blockchain_handlers/ethereum/connectors.py
@@ -146,7 +146,7 @@ class EthereumRPCProvider(object):
 
     def broadcast_tx(self, tx):
         logging.info('Broadcasting transaction with EthereumRPCProvider')
-        response = self.w3.eth.sendRawTransaction("0x" + tx).hex()
+        response = self.w3.eth.sendRawTransaction(tx).hex()
         return response
 
     def get_balance(self, address):

--- a/cert_issuer/blockchain_handlers/ethereum/signer.py
+++ b/cert_issuer/blockchain_handlers/ethereum/signer.py
@@ -1,6 +1,5 @@
-import rlp
-from ethereum import transactions
-from ethereum.utils import encode_hex
+import web3
+from eth_utils import to_hex
 
 from cert_issuer.errors import UnableToSignTxError
 from cert_issuer.models import Signer
@@ -28,12 +27,13 @@ class EthereumSigner(Signer):
     def sign_transaction(self, wif, transaction_to_sign):
         ##try to sign the transaction.
 
-        if isinstance(transaction_to_sign, transactions.Transaction):
+        if isinstance(transaction_to_sign, dict):
             try:
-                raw_tx = rlp.encode(transaction_to_sign.sign(wif, self.netcode))
-                raw_tx_hex = encode_hex(raw_tx)
+                transaction_to_sign['chainId'] = self.netcode
+                raw_tx = web3.Account.sign_transaction(transaction_to_sign, wif)['rawTransaction']
+                raw_tx_hex = to_hex(raw_tx)
                 return raw_tx_hex
             except Exception as msg:
                 return {'error': True, 'message': msg}
         else:
-            raise UnableToSignTxError('You are trying to sign a non transaction type')
+            raise UnableToSignTxError('sign_transaction expects a dict')

--- a/cert_issuer/blockchain_handlers/ethereum/signer.py
+++ b/cert_issuer/blockchain_handlers/ethereum/signer.py
@@ -36,4 +36,4 @@ class EthereumSigner(Signer):
             except Exception as msg:
                 return {'error': True, 'message': msg}
         else:
-            raise UnableToSignTxError('sign_transaction expects a dict')
+            raise UnableToSignTxError('"sign_transaction()" expects a dict representing an unsigned transaction with fields such as "gas", "to", "data", etc. run "$ python cert_issuer -h" for more information on transaction configuration.')

--- a/cert_issuer/blockchain_handlers/ethereum/transaction_handlers.py
+++ b/cert_issuer/blockchain_handlers/ethereum/transaction_handlers.py
@@ -1,6 +1,7 @@
 import logging
 
-from pycoin.serialize import b2h
+from web3 import Web3
+from eth_utils import to_hex, remove_0x_prefix
 
 from cert_issuer.errors import InsufficientFundsError
 from cert_issuer.blockchain_handlers.ethereum import tx_utils
@@ -14,14 +15,15 @@ class EthereumTransactionCreator(object):
         pass
 
     def create_transaction(self, tx_cost_constants, issuing_address, nonce, to_address, blockchain_bytes):
+        max_priority_fee_per_gas = tx_cost_constants.get_max_priority_fee_per_gas()
         gasprice = tx_cost_constants.get_gas_price()
         gaslimit = tx_cost_constants.get_gas_limit()
 
         transaction = tx_utils.create_ethereum_trx(
-            issuing_address,
             nonce,
             to_address,
             blockchain_bytes,
+            max_priority_fee_per_gas,
             gasprice,
             gaslimit)
 
@@ -29,12 +31,13 @@ class EthereumTransactionCreator(object):
 
 
 class EthereumTransactionHandler(TransactionHandler):
-    def __init__(self, connector, tx_cost_constants, secret_manager, issuing_address, prepared_inputs=None,
+    def __init__(self, connector, nonce, tx_cost_constants, secret_manager, issuing_address, prepared_inputs=None,
                  transaction_creator=EthereumTransactionCreator()):
         self.connector = connector
+        self.nonce = nonce
         self.tx_cost_constants = tx_cost_constants
         self.secret_manager = secret_manager
-        self.issuing_address = issuing_address
+        self.issuing_address = Web3.toChecksumAddress(issuing_address)
         # input transactions are not needed for Ether
         self.prepared_inputs = prepared_inputs
         self.transaction_creator = transaction_creator
@@ -46,7 +49,7 @@ class EthereumTransactionHandler(TransactionHandler):
         # for now transaction cost will be a constant: (25000 gas estimate times 20Gwei gasprice) from tx_utils
         # can later be calculated inside EthereumTransaction_creator
         transaction_cost = self.tx_cost_constants.get_recommended_max_cost()
-        logging.info('Total cost will be %d wei', transaction_cost)
+        logging.info('Total cost will be no more than %d wei', transaction_cost)
 
         if transaction_cost > self.balance:
             error_message = 'Please add {} wei to the address {}'.format(
@@ -55,7 +58,7 @@ class EthereumTransactionHandler(TransactionHandler):
             raise InsufficientFundsError(error_message)
 
     def issue_transaction(self, blockchain_bytes):
-        eth_data_field = b2h(blockchain_bytes)
+        eth_data_field = remove_0x_prefix(to_hex(blockchain_bytes))
         prepared_tx = self.create_transaction(blockchain_bytes)
         signed_tx = self.sign_transaction(prepared_tx)
         self.verify_transaction(signed_tx, eth_data_field)
@@ -65,9 +68,10 @@ class EthereumTransactionHandler(TransactionHandler):
     def create_transaction(self, blockchain_bytes):
         if self.balance:
             # it is assumed here that the address has sufficient funds, as the ensure_balance has just been checked
-            nonce = self.connector.get_address_nonce(self.issuing_address)
+            nonce = self.nonce or self.connector.get_address_nonce(self.issuing_address)
+            logging.info("NONCE IS %d", nonce)
             # Transactions in the first iteration will be send to burn address
-            toaddress = '0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead'
+            toaddress = Web3.toChecksumAddress('0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead')
             tx = self.transaction_creator.create_transaction(self.tx_cost_constants, self.issuing_address, nonce,
                                                              toaddress, blockchain_bytes)
 

--- a/cert_issuer/blockchain_handlers/ethereum/transaction_handlers.py
+++ b/cert_issuer/blockchain_handlers/ethereum/transaction_handlers.py
@@ -72,10 +72,9 @@ class EthereumTransactionHandler(TransactionHandler):
             logging.info("NONCE IS %d", nonce)
             # Transactions in the first iteration will be send to burn address
             toaddress = Web3.toChecksumAddress('0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead')
-            tx = self.transaction_creator.create_transaction(self.tx_cost_constants, self.issuing_address, nonce,
+            prepared_tx = self.transaction_creator.create_transaction(self.tx_cost_constants, self.issuing_address, nonce,
                                                              toaddress, blockchain_bytes)
 
-            prepared_tx = tx
             return prepared_tx
         else:
             raise InsufficientFundsError('Not sufficient ether to spend at: %s', self.issuing_address)

--- a/cert_issuer/blockchain_handlers/ethereum/tx_utils.py
+++ b/cert_issuer/blockchain_handlers/ethereum/tx_utils.py
@@ -3,12 +3,20 @@ import logging
 from cert_issuer.errors import UnverifiedTransactionError
 
 
-def create_ethereum_trx(issuing_address, nonce, to_address, blockchain_bytes, gasprice, gaslimit):
+def create_ethereum_trx(nonce, to_address, blockchain_bytes, max_priority_fee_per_gas, gasprice, gaslimit):
     # the actual value transfer is 0 in the Ethereum implementation
-    from ethereum.transactions import Transaction
     value = 0
-    tx = Transaction(nonce=nonce, gasprice=gasprice, startgas=gaslimit, to=to_address, value=value,
-                     data=blockchain_bytes)
+    tx = dict(
+        nonce=nonce,
+        gas=gaslimit,
+        to=to_address,
+        value=value,
+        data=blockchain_bytes)
+    if max_priority_fee_per_gas:
+        tx['maxFeePerGas'] = gasprice
+        tx['maxPriorityFeePerGas'] = max_priority_fee_per_gas
+    else:
+        tx['gasPrice'] = gasprice
     return tx
 
 

--- a/cert_issuer/config.py
+++ b/cert_issuer/config.py
@@ -69,8 +69,12 @@ def add_arguments(p):
     p.add_argument('--no_bitcoind', dest='bitcoind', default=True, action='store_false',
                    help='Default; do not use bitcoind connectors; use APIs instead', env_var='NO_BITCOIND')
     # ethereum arguments
+    p.add_argument('--nonce', default=0, type=int,
+                   help='sets nonce of ETH transaction. useful if you run your own transaction management system.', env_var='NONCE')
+    p.add_argument('--max_priority_fee_per_gas', default=0, type=int,
+                   help='decide the priority fee per gas spent for EIP-1559-compliant transactions (in wei, the smallest ETH unit)', env_var='MAX_PRIORITY_FEE_PER_GAS')
     p.add_argument('--gas_price', default=20000000000, type=int,
-                   help='decide the price per gas spent (in wei (smallest ETH unit))', env_var='GAS_PRICE')
+                   help='decide the price per gas spent. sets max_fee_per_gas for EIP-1559-compliant transactions.', env_var='GAS_PRICE')
     p.add_argument('--gas_limit', default=25000, type=int,
                    help='decide on the maximum spendable gas. gas_limit < 25000 might not be sufficient', env_var='GAS_LIMIT')
     p.add_argument('--etherscan_api_token', default=None, type=str,

--- a/ethereum_requirements.txt
+++ b/ethereum_requirements.txt
@@ -1,5 +1,2 @@
-web3<=4.4.1
-coincurve==7.1.0
-ethereum==2.3.1
-rlp<1
-eth-account<=0.3.0
+web3>=5.28.0
+eth-utils<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cert-core>=3.0.0
 cert-schema>=3.2.1
 merkletools==1.0.3
-configargparse==0.12.0
+configargparse==0.13.0
 glob2==0.6
 mock==2.0.0
 requests[security]>=2.18.4


### PR DESCRIPTION
Hi there, it's been about a year since the London hardfork (EIP-1559) changed how Ethereum gas fees are handled and it would be good for Blockcerts to use the updated transaction format. Two major reasons not to use the old transaction format anymore:
1) It's deprecated
2) It guarantees overpayment of gas fees. Miners will always receive the entire proposed gas fee, whereas with EIP-1559 txs, they will only receive the base fee plus the priority fee. For what it's worth, my gas fees have been about 75% less with this update.

[Here's a good primer on EIP-1559](https://medium.com/alchemy-api/the-developer-eip-1559-prep-kit-72dbe5c44545) if more background info is desired.

To enable EIP-1559-compliant transactions, I had to update some of the old web3-related libraries that were being used. Fortunately I was able to maintain backwards-compatibility (you can still use the old gas fee args) while also updating web3.py and eliminating a number of redundant libraries.
I've also added the option to pass an Ethereum nonce in, which is useful if you run your own transaction management system.

I think this update will greatly improve the usability of Ethereum Blockcerts and wanted to share it with the community. If you have any questions, please don't hesitate to ask.