### PR TITLE
fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apk add --update \
     && mkdir -p /etc/cert-issuer/data/unsigned_certificates \
     && mkdir /etc/cert-issuer/data/blockchain_certificates \
     && mkdir ~/.bitcoin \
-    && echo $'rpcuser=foo\nrpcpassword=bar\nrpcport=8332\nregtest=1\nrelaypriority=0\nrpcallowip=127.0.0.1\nrpcconnect=127.0.0.1\n' > /root/.bitcoin/bitcoin.conf \
+    && echo $'[regtest]\nrpcuser=foo\nrpcpassword=bar\nrpcport=8332\nregtest=1\nrelaypriority=0\nrpcallowip=127.0.0.1\nrpcconnect=127.0.0.1\n' > /root/.bitcoin/bitcoin.conf \
     && pip3 install /cert-issuer/. \
     && pip3 install -r /cert-issuer/ethereum_requirements.txt \
     && rm -r /usr/lib/python*/ensurepip \


### PR DESCRIPTION
Added the header [regtest] to bitcoin.conf, fixing the error:

"Error: Config setting for -rpcport only applied on regtest network when in [regtest] section."