### PR TITLE
chore(CI): re-enable semantic release publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ after_success:
   - pip install python-semantic-release
   - git config user.name botcerts
   - git config user.email botcerts@learningmachine.com
+  - git checkout master
   - semantic-release publish
 after_script:
   - nvm install 16

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ after_success:
   - pip install python-semantic-release
   - git config user.name botcerts
   - git config user.email botcerts@learningmachine.com
+  - git branch
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then git checkout master; fi' # trigger semantic release only on merge build
   - semantic-release publish
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ after_success:
   - pip install python-semantic-release
   - git config user.name botcerts
   - git config user.email botcerts@learningmachine.com
-  - git checkout master
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then git checkout master; fi' # trigger semantic release only on merge build
   - semantic-release publish
 after_script:
   - nvm install 16


### PR DESCRIPTION
it seems we are in a detached state, probably due to such a command early on in the CI process: https://app.travis-ci.com/github/blockchain-certificates/cert-issuer/builds/269278175#L173.

So we force back into master