### PR TITLE
Fetching current gas price from Etherscan

### DIFF
--- a/cert_issuer/blockchain_handlers/ethereum/__init__.py
+++ b/cert_issuer/blockchain_handlers/ethereum/__init__.py
@@ -69,9 +69,16 @@ def instantiate_blockchain_handlers(app_config):
     # ethereum chains
     elif chain.is_ethereum_type():
         nonce = app_config.nonce
-        cost_constants = EthereumTransactionCostConstants(app_config.max_priority_fee_per_gas, 
-                                                          app_config.gas_price, app_config.gas_limit)
         connector = EthereumServiceProviderConnector(chain, app_config)
+
+        if app_config.gas_price_dynamic:
+            gas_price = connector.gas_price()
+        else:
+            gas_price = app_config.gas_price
+
+        cost_constants = EthereumTransactionCostConstants(app_config.max_priority_fee_per_gas,
+                                                          gas_price, app_config.gas_limit)
+
         transaction_handler = EthereumTransactionHandler(connector, nonce, cost_constants, secret_manager,
                                                          issuing_address=issuing_address)
 

--- a/cert_issuer/blockchain_handlers/ethereum/connectors.py
+++ b/cert_issuer/blockchain_handlers/ethereum/connectors.py
@@ -228,6 +228,19 @@ class EtherscanBroadcaster(object):
             return balance
         raise BroadcastError(response.text)
 
+    def gas_price(self):
+        """
+        returns the gas price in wei
+        """
+        api_url = self.base_url + '?module=proxy&action=eth_gasPrice'
+        if self.api_token:
+            api_url += '&apikey=%s' % self.api_token
+        response = self.send_request('GET', api_url)
+        if int(response.status_code) == 200:
+            gas = int(response.json().get('result', None), 0)
+            logging.info('Gas price: %s', response.json())
+            return gas
+        raise BroadcastError(response.text)
     def get_address_nonce(self, address):
         """
         Looks up the address nonce of this address
@@ -291,20 +304,6 @@ class MyEtherWalletBroadcaster(object):
             logging.info('Balance check succeeded: %s', response.json())
             return balance
         logging.error('Error getting balance through MyEtherWallet. Error msg: %s', response.text)
-        raise BroadcastError(response.text)
-
-    def gas_price(self):
-        """
-        returns the gas price in wei
-        """
-        broadcast_url = self.base_url + '?module=proxy&action=eth_gasPrice'
-        if self.api_token:
-            broadcast_url += '&apikey=%s' % self.api_token
-        response = self.send_request('GET', broadcast_url)
-        if int(response.status_code) == 200:
-            gas = int(response.json().get('result', None), 0)
-            logging.info('Gas price: %s', response.json())
-            return gas
         raise BroadcastError(response.text)
 
     def get_address_nonce(self, address):

--- a/cert_issuer/blockchain_handlers/ethereum/connectors.py
+++ b/cert_issuer/blockchain_handlers/ethereum/connectors.py
@@ -89,6 +89,17 @@ class EthereumServiceProviderConnector(ServiceProviderConnector):
                 pass
         return 0
 
+    def gas_price(self):
+        for m in self.get_providers_for_chain(self.ethereum_chain, self.local_node):
+            try:
+                logging.info('m=%s', m)
+                gas_price = m.gas_price()
+                return gas_price
+            except Exception as e:
+                logging.info(e)
+                pass
+        return 0
+
     def get_address_nonce(self, address):
         for m in self.get_providers_for_chain(self.ethereum_chain, self.local_node):
             try:
@@ -280,6 +291,20 @@ class MyEtherWalletBroadcaster(object):
             logging.info('Balance check succeeded: %s', response.json())
             return balance
         logging.error('Error getting balance through MyEtherWallet. Error msg: %s', response.text)
+        raise BroadcastError(response.text)
+
+    def gas_price(self):
+        """
+        returns the gas price in wei
+        """
+        broadcast_url = self.base_url + '?module=proxy&action=eth_gasPrice'
+        if self.api_token:
+            broadcast_url += '&apikey=%s' % self.api_token
+        response = self.send_request('GET', broadcast_url)
+        if int(response.status_code) == 200:
+            gas = int(response.json().get('result', None), 0)
+            logging.info('Gas price: %s', response.json())
+            return gas
         raise BroadcastError(response.text)
 
     def get_address_nonce(self, address):

--- a/cert_issuer/config.py
+++ b/cert_issuer/config.py
@@ -75,6 +75,8 @@ def add_arguments(p):
                    help='decide the priority fee per gas spent for EIP-1559-compliant transactions (in wei, the smallest ETH unit)', env_var='MAX_PRIORITY_FEE_PER_GAS')
     p.add_argument('--gas_price', default=20000000000, type=int,
                    help='decide the price per gas spent. sets max_fee_per_gas for EIP-1559-compliant transactions.', env_var='GAS_PRICE')
+    p.add_argument('--gas_price_dynamic', default=False, type=bool,
+                   help='Fetch the current gas price from Etherscan. Requires etherscan_api_token to be set', env_var='GAS_PRICE_DYNAMIC')
     p.add_argument('--gas_limit', default=25000, type=int,
                    help='decide on the maximum spendable gas. gas_limit < 25000 might not be sufficient', env_var='GAS_LIMIT')
     p.add_argument('--etherscan_api_token', default=None, type=str,


### PR DESCRIPTION
Currently cert issuer supports setting a fixed gas price to issue credentials into the Ethereum blockchain. When issuing credentials via an automated process, using the cert issuer APIs, a fixed value would need constant intervention or it needs to have a high value. Neither of which is scalable or cost efficient.

To handle this case, I have introduced a `gas_dynamic_price` config which when set to `True`, will fetch the current gas price from Etherscan.

Issue: https://github.com/blockchain-certificates/cert-issuer/issues/285