### PR TITLE
Support for issuing Credentials to the Ethereum Blockchain via API

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,20 +16,14 @@ def get_config():
         config = cert_issuer.config.get_config()
     return config
 
-@app.route('/cert_issuer/api/v1.0/issue', methods=['POST'])
-def btc_issue():
+@app.route('/cert_issuer/api/v1.0/issue/', methods=['POST'])
+@app.route('/cert_issuer/api/v1.0/issue/<handler>', methods=['POST'])
+def issue(handler=None):
+    blockchain_handler = ethereum if handler == 'ethereum' else bitcoin
     config = get_config()
-    certificate_batch_handler, transaction_handler, connector = \
-            bitcoin.instantiate_blockchain_handlers(config, False)
-    certificate_batch_handler.set_certificates_in_batch(request.json)
-    cert_issuer.issue_certificates.issue(config, certificate_batch_handler, transaction_handler)
-    return json.dumps(certificate_batch_handler.proof)
 
-@app.route('/cert_issuer/api/v1.0/eth_issue', methods=['POST'])
-def eth_issue():
-    config = get_config()
     certificate_batch_handler, transaction_handler, connector = \
-            ethereum.instantiate_blockchain_handlers(config, False)
+            blockchain_handler.instantiate_blockchain_handlers(config, False)
     certificate_batch_handler.set_certificates_in_batch(request.json)
     cert_issuer.issue_certificates.issue(config, certificate_batch_handler, transaction_handler)
     return json.dumps(certificate_batch_handler.proof)

--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from flask import Flask, jsonify, request, abort
 from subprocess import call
 
 import cert_issuer.config
-from cert_issuer.blockchain_handlers import bitcoin
+from cert_issuer.blockchain_handlers import bitcoin, ethereum
 import cert_issuer.issue_certificates
 
 app = Flask(__name__)
@@ -17,10 +17,19 @@ def get_config():
     return config
 
 @app.route('/cert_issuer/api/v1.0/issue', methods=['POST'])
-def issue():
+def btc_issue():
     config = get_config()
     certificate_batch_handler, transaction_handler, connector = \
             bitcoin.instantiate_blockchain_handlers(config, False)
+    certificate_batch_handler.set_certificates_in_batch(request.json)
+    cert_issuer.issue_certificates.issue(config, certificate_batch_handler, transaction_handler)
+    return json.dumps(certificate_batch_handler.proof)
+
+@app.route('/cert_issuer/api/v1.0/eth_issue', methods=['POST'])
+def eth_issue():
+    config = get_config()
+    certificate_batch_handler, transaction_handler, connector = \
+            ethereum.instantiate_blockchain_handlers(config, False)
     certificate_batch_handler.set_certificates_in_batch(request.json)
     cert_issuer.issue_certificates.issue(config, certificate_batch_handler, transaction_handler)
     return json.dumps(certificate_batch_handler.proof)

--- a/cert_issuer/blockchain_handlers/ethereum/__init__.py
+++ b/cert_issuer/blockchain_handlers/ethereum/__init__.py
@@ -61,20 +61,12 @@ def instantiate_blockchain_handlers(app_config, file_mode=True):
     chain = app_config.chain
     secret_manager = initialize_signer(app_config)
 
-    if file_mode:
-        certificate_batch_handler = CertificateBatchHandler(
-            secret_manager=secret_manager,
-            certificate_handler=CertificateV3Handler(app_config),
-            merkle_tree=MerkleTreeGenerator(),
-            config=app_config
-        )
-    else:
-        certificate_batch_handler = CertificateBatchWebHandler(
-            secret_manager=secret_manager,
-            certificate_handler=CertificateWebV3Handler(app_config),
-            merkle_tree=MerkleTreeGenerator(),
-            config=app_config
-        )
+    certificate_batch_handler = (CertificateBatchHandler if file_mode else CertificateBatchWebHandler)(
+        secret_manager=secret_manager,
+        certificate_handler=(CertificateV3Handler if file_mode else CertificateWebV3Handler)(app_config),
+        merkle_tree=MerkleTreeGenerator(),
+        config=app_config
+    )
 
     if chain.is_mock_type():
         transaction_handler = MockTransactionHandler()

--- a/cert_issuer/blockchain_handlers/ethereum/__init__.py
+++ b/cert_issuer/blockchain_handlers/ethereum/__init__.py
@@ -3,7 +3,7 @@ import os
 
 from cert_core import UnknownChainError
 
-from cert_issuer.certificate_handlers import CertificateBatchHandler, CertificateV3Handler
+from cert_issuer.certificate_handlers import CertificateBatchHandler, CertificateV3Handler, CertificateBatchWebHandler, CertificateWebV3Handler
 from cert_issuer.blockchain_handlers.ethereum.connectors import EthereumServiceProviderConnector
 from cert_issuer.blockchain_handlers.ethereum.signer import EthereumSigner
 from cert_issuer.blockchain_handlers.ethereum.transaction_handlers import EthereumTransactionHandler
@@ -56,14 +56,26 @@ def initialize_signer(app_config):
     return secret_manager
 
 
-def instantiate_blockchain_handlers(app_config):
+def instantiate_blockchain_handlers(app_config, file_mode=True):
     issuing_address = app_config.issuing_address
     chain = app_config.chain
     secret_manager = initialize_signer(app_config)
-    certificate_batch_handler = CertificateBatchHandler(secret_manager=secret_manager,
-                                                        certificate_handler=CertificateV3Handler(),
-                                                        merkle_tree=MerkleTreeGenerator(),
-                                                        config=app_config)
+
+    if file_mode:
+        certificate_batch_handler = CertificateBatchHandler(
+            secret_manager=secret_manager,
+            certificate_handler=CertificateV3Handler(app_config),
+            merkle_tree=MerkleTreeGenerator(),
+            config=app_config
+        )
+    else:
+        certificate_batch_handler = CertificateBatchWebHandler(
+            secret_manager=secret_manager,
+            certificate_handler=CertificateWebV3Handler(app_config),
+            merkle_tree=MerkleTreeGenerator(),
+            config=app_config
+        )
+
     if chain.is_mock_type():
         transaction_handler = MockTransactionHandler()
     # ethereum chains

--- a/cert_issuer/blockchain_handlers/ethereum/transaction_handlers.py
+++ b/cert_issuer/blockchain_handlers/ethereum/transaction_handlers.py
@@ -37,7 +37,7 @@ class EthereumTransactionHandler(TransactionHandler):
         self.nonce = nonce
         self.tx_cost_constants = tx_cost_constants
         self.secret_manager = secret_manager
-        self.issuing_address = Web3.toChecksumAddress(issuing_address)
+        self.issuing_address = Web3.to_checksum_address(issuing_address)
         # input transactions are not needed for Ether
         self.prepared_inputs = prepared_inputs
         self.transaction_creator = transaction_creator
@@ -71,7 +71,7 @@ class EthereumTransactionHandler(TransactionHandler):
             nonce = self.nonce or self.connector.get_address_nonce(self.issuing_address)
             logging.info("NONCE IS %d", nonce)
             # Transactions in the first iteration will be send to burn address
-            toaddress = Web3.toChecksumAddress('0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead')
+            toaddress = Web3.to_checksum_address('0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead')
             prepared_tx = self.transaction_creator.create_transaction(self.tx_cost_constants, self.issuing_address, nonce,
                                                              toaddress, blockchain_bytes)
 

--- a/cert_issuer/normalization_handler.py
+++ b/cert_issuer/normalization_handler.py
@@ -14,7 +14,7 @@ class JSONLDHandler:
 
     @staticmethod
     def preload_contexts():
-        if CONFIG.context_urls is None or CONFIG.context_file_paths is None:
+        if CONFIG is None or CONFIG.context_urls is None or CONFIG.context_file_paths is None:
             return
         for (url, path) in zip(CONFIG.context_urls, CONFIG.context_file_paths):
             with open(os.path.join(os.getcwd(), path)) as context_file:


### PR DESCRIPTION
Currently the `/cert_issuer/api/v1.0/issue` API only supports issuing credentials in the Bitcoin Blockchain.


This PR adds the ability to issue credentials into the Ethereum Blockchain using the same API. The API contract has been updated as follows
- `POST /cert_issuer/api/v1.0/issue` - issues to the Bitcoin Blockchain, which is the existing and default behaviour.
- `POST /cert_issuer/api/v1.0/issue/bitcoin` - issues to the Bitcoin Blockchain, which is also supported for consistency.
- `POST /cert_issuer/api/v1.0/issue/ethereum` - issues to the Ethereum Blockchain.